### PR TITLE
ci: use github-pages-deploy reusable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,32 +5,16 @@ on:
     workflows: ["Update Repository Data"]
     types:
       - completed
-
+  workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    uses: actionsforge/actions/.github/workflows/github-pages-deploy.yml@main
+    with:
+      path: ./docs


### PR DESCRIPTION
## Summary
- Replace inline Pages deploy with `actionsforge/actions/.github/workflows/github-pages-deploy.yml@main`
- Keep `workflow_run` on Update Repository Data; add success gate and `workflow_dispatch`
- Drop caller concurrency (lives on the reusable)

## Test plan
- [ ] Manually dispatch Pages or wait for next Update Repository Data run

Closes #50