### PR TITLE
chore: pin GitHub Actions to latest and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/update-repositories.yml
+++ b/.github/workflows/update-repositories.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 

--- a/docs/repositories.json
+++ b/docs/repositories.json
@@ -36,7 +36,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-04T23:48:44Z",
-      "updated_at": "2026-07-10T19:08:13Z",
+      "updated_at": "2026-07-25T03:26:35Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -151,7 +151,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-28T11:24:14Z",
-      "updated_at": "2026-07-01T18:45:18Z",
+      "updated_at": "2026-07-25T03:26:41Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -197,7 +197,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-06T06:55:57Z",
-      "updated_at": "2026-06-20T09:58:30Z",
+      "updated_at": "2026-07-25T03:27:03Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -243,7 +243,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-21T12:42:22Z",
-      "updated_at": "2026-06-23T18:48:36Z",
+      "updated_at": "2026-07-25T03:26:59Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -266,7 +266,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-03-19T08:14:59Z",
-      "updated_at": "2026-06-20T09:31:27Z",
+      "updated_at": "2026-07-25T03:27:11Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -312,7 +312,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-10T23:47:00Z",
-      "updated_at": "2026-07-11T01:56:07Z",
+      "updated_at": "2026-07-25T03:26:27Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -335,7 +335,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-13T12:17:12Z",
-      "updated_at": "2026-07-14T12:14:17Z",
+      "updated_at": "2026-07-25T03:26:10Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -404,7 +404,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-13T01:39:18Z",
-      "updated_at": "2026-06-20T09:10:47Z",
+      "updated_at": "2026-07-25T03:27:15Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -473,7 +473,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-19T02:33:25Z",
-      "updated_at": "2026-07-19T03:31:28Z",
+      "updated_at": "2026-07-25T03:26:06Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -496,7 +496,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2024-03-16T02:06:32Z",
-      "updated_at": "2026-07-24T18:14:09Z",
+      "updated_at": "2026-07-25T03:59:14Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -519,7 +519,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2025-06-01T12:08:27Z",
-      "updated_at": "2026-07-24T05:57:37Z",
+      "updated_at": "2026-07-25T04:43:03Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -542,7 +542,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2024-03-10T07:21:24Z",
-      "updated_at": "2026-07-24T18:19:56Z",
+      "updated_at": "2026-07-25T04:12:23Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -565,7 +565,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-11T03:11:46Z",
-      "updated_at": "2026-07-14T12:26:01Z",
+      "updated_at": "2026-07-25T03:26:16Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -657,7 +657,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-14T09:31:49Z",
-      "updated_at": "2026-06-29T22:34:48Z",
+      "updated_at": "2026-07-25T03:27:21Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -749,7 +749,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-12T10:38:39Z",
-      "updated_at": "2026-07-13T07:15:47Z",
+      "updated_at": "2026-07-25T03:26:21Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -864,7 +864,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-07-03T11:47:58Z",
-      "updated_at": "2026-07-04T03:50:29Z",
+      "updated_at": "2026-07-25T03:28:29Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -887,7 +887,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-19T10:59:24Z",
-      "updated_at": "2026-06-20T07:43:37Z",
+      "updated_at": "2026-07-25T03:27:23Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -910,7 +910,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-04-08T13:16:33Z",
-      "updated_at": "2026-06-20T09:44:39Z",
+      "updated_at": "2026-07-25T03:27:10Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -933,7 +933,7 @@
       "forks_count": 0,
       "has_pages": true,
       "created_at": "2026-06-09T05:22:52Z",
-      "updated_at": "2026-06-20T10:20:17Z",
+      "updated_at": "2026-07-25T03:26:59Z",
       "owner": {
         "login": "jajera",
         "avatar_url": "https://avatars.githubusercontent.com/u/37360952?v=4",
@@ -1071,7 +1071,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-01-04T12:01:09Z",
-      "updated_at": "2026-06-20T00:08:48Z",
+      "updated_at": "2026-07-25T01:38:39Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1094,7 +1094,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-13T20:03:04Z",
-      "updated_at": "2026-06-20T02:24:02Z",
+      "updated_at": "2026-07-25T01:37:59Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1117,7 +1117,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-20T20:34:59Z",
-      "updated_at": "2026-06-20T01:19:15Z",
+      "updated_at": "2026-07-25T01:42:17Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1140,7 +1140,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-23T00:47:31Z",
-      "updated_at": "2026-06-20T01:37:49Z",
+      "updated_at": "2026-07-25T01:39:00Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1163,7 +1163,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-05-16T13:06:58Z",
-      "updated_at": "2026-06-20T02:45:34Z",
+      "updated_at": "2026-07-25T01:38:09Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1186,7 +1186,7 @@
       "forks_count": 1,
       "has_pages": false,
       "created_at": "2025-05-29T20:25:15Z",
-      "updated_at": "2026-06-20T02:36:10Z",
+      "updated_at": "2026-07-25T01:38:13Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1209,7 +1209,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2026-01-28T03:44:46Z",
-      "updated_at": "2026-06-20T02:48:48Z",
+      "updated_at": "2026-07-25T01:38:04Z",
       "owner": {
         "login": "actionsforge",
         "avatar_url": "https://avatars.githubusercontent.com/u/193304877?v=4",
@@ -1232,7 +1232,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-25T23:52:00Z",
-      "updated_at": "2026-03-13T05:15:09Z",
+      "updated_at": "2026-07-25T04:10:21Z",
       "owner": {
         "login": "cloudbuildlab",
         "avatar_url": "https://avatars.githubusercontent.com/u/207421664?v=4",
@@ -1255,7 +1255,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-30T18:43:25Z",
-      "updated_at": "2025-07-07T12:02:17Z",
+      "updated_at": "2026-07-25T04:10:29Z",
       "owner": {
         "login": "cloudbuildlab",
         "avatar_url": "https://avatars.githubusercontent.com/u/207421664?v=4",
@@ -1393,7 +1393,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-11-08T10:14:40Z",
-      "updated_at": "2025-07-07T12:01:33Z",
+      "updated_at": "2026-07-25T04:10:37Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1439,7 +1439,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-12-03T01:41:13Z",
-      "updated_at": "2025-07-07T11:58:16Z",
+      "updated_at": "2026-07-25T04:10:58Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1485,7 +1485,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-12-12T05:36:33Z",
-      "updated_at": "2025-07-07T11:59:15Z",
+      "updated_at": "2026-07-25T04:10:33Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1508,7 +1508,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-12-12T10:09:14Z",
-      "updated_at": "2025-07-07T12:04:33Z",
+      "updated_at": "2026-07-25T04:11:01Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1531,7 +1531,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-12-13T21:41:42Z",
-      "updated_at": "2025-07-07T12:03:58Z",
+      "updated_at": "2026-07-25T04:11:01Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1554,7 +1554,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2024-12-20T03:51:26Z",
-      "updated_at": "2026-04-24T06:32:10Z",
+      "updated_at": "2026-07-25T04:10:35Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1600,7 +1600,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-02-07T12:09:01Z",
-      "updated_at": "2025-06-21T03:44:51Z",
+      "updated_at": "2026-07-25T04:19:27Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1692,7 +1692,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-02-25T05:46:41Z",
-      "updated_at": "2025-09-24T20:40:07Z",
+      "updated_at": "2026-07-25T04:10:29Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1715,7 +1715,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-03-01T03:03:24Z",
-      "updated_at": "2025-06-21T03:48:27Z",
+      "updated_at": "2026-07-25T04:19:39Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1738,7 +1738,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-03-09T00:59:27Z",
-      "updated_at": "2025-06-21T03:55:17Z",
+      "updated_at": "2026-07-25T04:10:29Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -1830,7 +1830,7 @@
       "forks_count": 0,
       "has_pages": false,
       "created_at": "2025-04-17T05:03:56Z",
-      "updated_at": "2025-06-21T03:52:32Z",
+      "updated_at": "2026-07-25T05:06:36Z",
       "owner": {
         "login": "tfstack",
         "avatar_url": "https://avatars.githubusercontent.com/u/181625549?v=4",
@@ -2666,7 +2666,7 @@
       "github-actions": 7,
       "devcontainer-features": 6
     },
-    "lastUpdated": "2026-07-25T01:27:43.997Z",
+    "lastUpdated": "2026-07-25T05:13:48.968Z",
     "sources": {
       "users": [
         "jajera"


### PR DESCRIPTION
## Summary
- SHA-pin outdated GitHub Actions to latest releases
- Ensure weekly Dependabot for `github-actions`

## Test plan
- [ ] PR checks pass

Closes #52